### PR TITLE
Fixed the duping of gold nuggets

### DIFF
--- a/src/main/java/aldrigos/mc/alchemy/listeners/BrewListener.java
+++ b/src/main/java/aldrigos/mc/alchemy/listeners/BrewListener.java
@@ -32,6 +32,7 @@ public class BrewListener implements Listener {
 
         if(ingr != null && api.isIngredient(ingr)) {
             var clone = ingr.clone();
+            clone.setAmount(1);
             ingr.setAmount(ingr.getAmount() - 1);
 
             Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {


### PR DESCRIPTION
When clicking whith more than one gold nugget in a brewing stand only one gets removed from the cursor, but all got copied to the brewing stand.
This just sets the amount of the copied itemstack to 1.